### PR TITLE
Prevent object spawn overlap with players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-06-28
+- Prevent objects from spawning on top of players
+
 ## 2025-06-27
 - Revise character generator prompt for humanoid proportions and 3×3×3 size limit
 

--- a/js/aiBuilder.js
+++ b/js/aiBuilder.js
@@ -83,6 +83,8 @@ export class AIBuilder {
             Math.max(0.5, position.y || 0.5) / 5,
             Math.max(-50, Math.min(50, position.z || 0)) / 5
         );
+
+        if (this.buildTool.isLocationOccupiedByPlayer(buildObject.position)) return;
         const scale = objectData.scale || { x: 1, y: 1, z: 1 };
         buildObject.scale.set(
             Math.max(0.1, Math.min(10, scale.x || 1)) / 5,

--- a/js/buildTool.js
+++ b/js/buildTool.js
@@ -141,6 +141,8 @@ export class BuildTool {
     const previewMesh = this.previewManager.getMesh();
     if (!previewMesh || !this.enabled) return;
 
+    if (this.isLocationOccupiedByPlayer(previewMesh.position)) return;
+
     // Create a new object at the preview position
     const buildGeometry = previewMesh.geometry.clone();
     const materialIndex = this.previewManager.getCurrentMaterialIndex();
@@ -253,6 +255,8 @@ export class BuildTool {
       buildData.position.y,
       buildData.position.z
     );
+
+    if (this.isLocationOccupiedByPlayer(buildObject.position)) return;
     buildObject.scale.set(
       buildData.scale.x,
       buildData.scale.y,
@@ -277,6 +281,18 @@ export class BuildTool {
   // Set the room for multiplayer build syncing
   setRoom(room) {
     this.room = room;
+  }
+
+  isLocationOccupiedByPlayer(position, radius = 1) {
+    let occupied = false;
+    this.scene.traverse((obj) => {
+      if (obj.userData && obj.userData.isPlayer) {
+        const playerPos = new THREE.Vector3();
+        obj.getWorldPosition(playerPos);
+        if (playerPos.distanceTo(position) < radius) occupied = true;
+      }
+    });
+    return occupied;
   }
 
   toggleBuildMode() {

--- a/js/objectCreator.js
+++ b/js/objectCreator.js
@@ -36,6 +36,8 @@ export class ObjectCreator {
         vector.add(this.camera.position);
         mesh.position.copy(vector);
 
+        if (this.buildTool.isLocationOccupiedByPlayer(mesh.position)) return null;
+
         const objectId = 'adv_build_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
         mesh.userData.id = objectId;
         mesh.userData.createdAt = Date.now();
@@ -53,6 +55,8 @@ export class ObjectCreator {
         duplicatedObject.position.copy(objectToDuplicate.position).add(new THREE.Vector3(0.5, 0, 0.5));
         duplicatedObject.rotation.copy(objectToDuplicate.rotation);
         duplicatedObject.scale.copy(objectToDuplicate.scale);
+
+        if (this.buildTool.isLocationOccupiedByPlayer(duplicatedObject.position)) return null;
 
         duplicatedObject.castShadow = true;
         duplicatedObject.receiveShadow = true;
@@ -88,6 +92,8 @@ export class ObjectCreator {
 
         const buildObject = new THREE.Mesh(geometry, material);
         buildObject.position.set(buildData.position.x, buildData.position.y, buildData.position.z);
+
+        if (this.buildTool.isLocationOccupiedByPlayer(buildObject.position)) return null;
         buildObject.scale.set(buildData.scale.x, buildData.scale.y, buildData.scale.z);
         buildObject.rotation.set(buildData.rotation.x, buildData.rotation.y, buildData.rotation.z);
         

--- a/js/player.js
+++ b/js/player.js
@@ -222,6 +222,7 @@ function _createDefaultPlayerModel(playerGroup, username, characterSpec, default
 
 export function createPlayerModel(three, username, characterSpec) {
     const playerGroup = new THREE.Group();
+    playerGroup.userData.isPlayer = true;
     
     // Store character spec in userData for reference
     if (characterSpec) {


### PR DESCRIPTION
## Summary
- block building objects if a player occupies that spot
- mark each player model with `isPlayer`
- record these changes in the changelog

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d98d797fc8332b8dfe21cdcd5674f