### PR TITLE
Add open/close controls for minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2018 Add map UI button and close control
 - 1958 Reserve spawn area so players don't load inside objects
 - 1928 Add rotate and undo buttons to basic build mode
 - 1928 Add pyramid shape to builder tool
@@ -10,7 +11,6 @@
 - Add AGENTS.md with changelog and testing guidelines
 - **cfb2ea7** Initial commit
 - **08f04d4** Starting Point
-- **c210851** Add static object markers to MapUI
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -4,4 +4,5 @@
 - **7d0177a** Merge: extend MapUI to handle scene objects
 - **d335b69** Use texture sampling for map terrain
 - **858612b** Merge: load texture and update terrain rendering
+- **c210851** Add static object markers to MapUI
 

--- a/styles/map.css
+++ b/styles/map.css
@@ -63,3 +63,35 @@
     border-radius: 5px;
     background-color: #1a2a40; /* Same as TERRAIN_LOW_COLOR */
 }
+
+#map-button {
+    position: fixed;
+    bottom: 50px;
+    left: 50px;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    text-align: center;
+    line-height: 60px;
+    font-weight: bold;
+    color: #333;
+    z-index: 1000;
+    touch-action: none;
+    cursor: pointer;
+}
+
+#close-map {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 20px;
+    height: 20px;
+    background-color: rgba(255, 255, 255, 0.7);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 20px;
+    font-weight: bold;
+    color: #333;
+    cursor: pointer;
+}

--- a/ui/mapUI.js
+++ b/ui/mapUI.js
@@ -79,6 +79,7 @@ export class MapUI {
                     <span id="zoom-level-label"></span>
                     <button id="zoom-in-btn">+</button>
                 </div>
+                <div id="close-map">✕</div>
             </div>
         `;
 
@@ -90,7 +91,15 @@ export class MapUI {
         
         this.ctx = this.mapCanvas.getContext('2d');
 
+        const mapButton = document.createElement('div');
+        mapButton.id = 'map-button';
+        mapButton.innerText = 'MAP';
+        gameContainer.appendChild(mapButton);
+
         gameContainer.appendChild(this.mapContainer);
+
+        mapButton.addEventListener('click', () => this.toggle());
+        this.mapContainer.querySelector('#close-map').addEventListener('click', () => this.toggle());
 
         window.addEventListener('keydown', (e) => {
             if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {


### PR DESCRIPTION
## Summary
- create map button and close button
- style the new controls
- archive old changelog entry
- log new update

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685daa91c97c8332854d7e172ea3e7a9