### PR TITLE
Add changelog modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2205 Display changelog in modal overlay
 - 2153 Add changelog button above chat
 - 2147 Add HouseBlocks mesh kit
 - 2110 Fix build tool using undefined material index in object creator
@@ -10,7 +11,6 @@
 - 1928 Add rotate and undo buttons to basic build mode
 - 1928 Add pyramid shape to builder tool
 - 1918 Prevent objects from spawning on top of players
-- 1918 Revise character generator prompt for humanoid proportions and 3×3×3 size limit
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -11,4 +11,5 @@
 
 - 2118 Make AI builder asynchronous with progress indicator
 - Document using the current UTC date when updating the changelog
+- 1918 Revise character generator prompt for humanoid proportions and 3×3×3 size limit
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="styles/ads.css">
   <link rel="stylesheet" href="styles/responsive.css">
   <link rel="stylesheet" href="styles/map.css">
+  <link rel="stylesheet" href="styles/changelog.css">
   <script type="importmap">
     {
       "imports": {

--- a/styles/changelog.css
+++ b/styles/changelog.css
@@ -1,0 +1,36 @@
+#changelog-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 20px;
+  border-radius: 10px;
+  z-index: 2100;
+  width: 90%;
+  max-width: 600px;
+  max-height: 80%;
+  overflow-y: auto;
+  display: none;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+#close-changelog {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 20px;
+  height: 20px;
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+  text-align: center;
+  line-height: 20px;
+  font-weight: bold;
+  color: #333;
+  cursor: pointer;
+}
+
+#changelog-content {
+  white-space: pre-wrap;
+}

--- a/ui/changelogUI.js
+++ b/ui/changelogUI.js
@@ -6,8 +6,27 @@ export class ChangelogUI {
         changelogButton.innerText = 'CHANGELOG';
         gameContainer.appendChild(changelogButton);
 
-        changelogButton.addEventListener('click', () => {
-            window.open('CHANGELOG.md', '_blank');
+        const changelogModal = document.createElement('div');
+        changelogModal.id = 'changelog-modal';
+        changelogModal.innerHTML = `
+            <div id="close-changelog">✕</div>
+            <pre id="changelog-content"></pre>
+        `;
+        gameContainer.appendChild(changelogModal);
+
+        changelogButton.addEventListener('click', async () => {
+            changelogModal.style.display = 'block';
+            const contentEl = changelogModal.querySelector('#changelog-content');
+            try {
+                const text = await fetch('CHANGELOG.md').then(r => r.text());
+                contentEl.textContent = text;
+            } catch (e) {
+                contentEl.textContent = 'Failed to load changelog.';
+            }
+        });
+
+        changelogModal.querySelector('#close-changelog').addEventListener('click', () => {
+            changelogModal.style.display = 'none';
         });
     }
 }


### PR DESCRIPTION
## Summary
- display changelog file in an in-game modal
- style new modal overlay
- link stylesheet in index.html
- archive an old changelog entry
- document new modal behaviour

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dc37918008332996d274e565a727b