### PR TITLE
Add chat log and immediate display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2214 Show sent chat immediately and keep log of messages
 - 2206 Introduce mobile-device class for mobile controls
 - 2205 Display changelog in modal overlay
 - 2153 Add changelog button above chat
@@ -10,8 +11,6 @@
 - 2018 Add map UI button and close control
 - 1958 Reserve spawn area so players don't load inside objects
 - 1928 Add rotate and undo buttons to basic build mode
-- 1928 Add pyramid shape to builder tool
-- 1918 Prevent objects from spawning on top of players
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -12,4 +12,6 @@
 - 2118 Make AI builder asynchronous with progress indicator
 - Document using the current UTC date when updating the changelog
 - 1918 Revise character generator prompt for humanoid proportions and 3×3×3 size limit
+- 1918 Prevent objects from spawning on top of players
+- 1928 Add pyramid shape to builder tool
 

--- a/js/multiplayerManager.js
+++ b/js/multiplayerManager.js
@@ -133,6 +133,15 @@ export class MultiplayerManager {
     displayChatMessage(clientId, message) {
         this.chatMessages[clientId].textContent = message;
         this.chatMessages[clientId].style.display = 'block';
+        const chatLog = document.getElementById('chat-log');
+        if (chatLog) {
+            const peerInfo = clientId === this.room.clientId ? { username: 'You' } : (this.room.peers[clientId] || {});
+            const name = peerInfo.username || `Player${clientId.substring(0, 4)}`;
+            const entry = document.createElement('div');
+            entry.textContent = `${name}: ${message}`;
+            chatLog.appendChild(entry);
+            chatLog.scrollTop = chatLog.scrollHeight;
+        }
         setTimeout(() => {
             if (this.chatMessages[clientId]) this.chatMessages[clientId].style.display = 'none';
         }, 5000);

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -71,3 +71,11 @@
   cursor: pointer;
 }
 
+#chat-log {
+  max-height: 150px;
+  overflow-y: auto;
+  margin-bottom: 8px;
+  color: #fff;
+  font-size: 14px;
+}
+

--- a/ui/chatUI.js
+++ b/ui/chatUI.js
@@ -2,6 +2,7 @@ export class ChatUI {
     constructor(dependencies) {
         this.playerControls = dependencies.playerControls;
         this.room = dependencies.room;
+        this.multiplayerManager = dependencies.multiplayerManager;
     }
 
     create() {
@@ -9,6 +10,11 @@ export class ChatUI {
 
         const chatInputContainer = document.createElement('div');
         chatInputContainer.id = 'chat-input-container';
+
+        const chatLog = document.createElement('div');
+        chatLog.id = 'chat-log';
+        chatInputContainer.appendChild(chatLog);
+
         const chatInput = document.createElement('input');
         chatInput.id = 'chat-input';
         chatInput.type = 'text';
@@ -27,6 +33,7 @@ export class ChatUI {
         chatButton.innerText = 'CHAT';
         gameContainer.appendChild(chatButton);
 
+
         const openChatInput = () => {
             chatInputContainer.style.display = 'block';
             chatInput.focus();
@@ -43,6 +50,9 @@ export class ChatUI {
             const message = chatInput.value.trim();
             if (message) {
                 this.room.updatePresence({ chat: { message, timestamp: Date.now() } });
+                if (this.multiplayerManager) {
+                    this.multiplayerManager.displayChatMessage(this.room.clientId, message);
+                }
                 closeChatInput();
             }
         }


### PR DESCRIPTION
## Summary
- show chat logs above the input box
- instantly display your sent messages and log them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dc5e3a3fc8332b6274b146b8d8112