### PR TITLE
Add fading effect to chat bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2218 Fade chat bubbles before hiding
 - 2214 Show sent chat immediately and keep log of messages
 - 2206 Introduce mobile-device class for mobile controls
 - 2205 Display changelog in modal overlay

--- a/js/multiplayerManager.js
+++ b/js/multiplayerManager.js
@@ -131,8 +131,11 @@ export class MultiplayerManager {
     }
 
     displayChatMessage(clientId, message) {
-        this.chatMessages[clientId].textContent = message;
-        this.chatMessages[clientId].style.display = 'block';
+        const bubble = this.chatMessages[clientId];
+        bubble.textContent = message;
+        bubble.style.display = 'block';
+        bubble.style.opacity = '1';
+        bubble.classList.remove('fade-out');
         const chatLog = document.getElementById('chat-log');
         if (chatLog) {
             const peerInfo = clientId === this.room.clientId ? { username: 'You' } : (this.room.peers[clientId] || {});
@@ -143,7 +146,14 @@ export class MultiplayerManager {
             chatLog.scrollTop = chatLog.scrollHeight;
         }
         setTimeout(() => {
-            if (this.chatMessages[clientId]) this.chatMessages[clientId].style.display = 'none';
+            if (bubble) {
+                const endHandler = () => {
+                    bubble.style.display = 'none';
+                    bubble.removeEventListener('transitionend', endHandler);
+                };
+                bubble.addEventListener('transitionend', endHandler, { once: true });
+                bubble.classList.add('fade-out');
+            }
         }, 5000);
     }
 

--- a/styles/overlays.css
+++ b/styles/overlays.css
@@ -26,5 +26,11 @@
   transform: translate(-50%, -100%);
   margin-top: -25px;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+  opacity: 1;
+  transition: opacity 0.5s;
+}
+
+.chat-message.fade-out {
+  opacity: 0;
 }
 


### PR DESCRIPTION
## Summary
- fade out chat bubbles after a short delay
- support fading via CSS transition
- document the fading change

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dc6d957f4833293c4014e9c558fc7