### PR TITLE
Add asset download options and glb tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2242 Add options menu with asset downloader and glb analysis scripts
 - 2221 Document new agents directory and split instructions
 - 2218 Fade chat bubbles before hiding
 - 2214 Show sent chat immediately and keep log of messages
@@ -10,7 +11,6 @@
 - 2147 Add HouseBlocks mesh kit
 - 2110 Fix build tool using undefined material index in object creator
 - 2057 Rework character creator modal layout for clearer flow
-- 2018 Add map UI button and close control
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -17,4 +17,5 @@
 
 - 1958 Reserve spawn area so players don't load inside objects
 - 1928 Add rotate and undo buttons to basic build mode
+- 2018 Add map UI button and close control
 

--- a/assets.json
+++ b/assets.json
@@ -20,5 +20,21 @@
       "name": "Input controls",
       "url": "js/controls.js"
     }
+    ,
+    {
+      "type": "model",
+      "name": "Idle animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Z1/player/Animation_Idle_withSkin.glb"
+    },
+    {
+      "type": "model",
+      "name": "Walking animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Z1/player/Animation_Walking_withSkin.glb"
+    },
+    {
+      "type": "model",
+      "name": "Running animation",
+      "url": "https://file.garden/Zy7B0LkdIVpGyzA1/Z1/player/Animation_Running_withSkin.glb"
+    }
   ]
 }

--- a/glbanalyzer.py
+++ b/glbanalyzer.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Simple GLB analyzer for rigging and skeleton information."""
+
+import struct
+import json
+import sys
+from typing import Tuple, Dict, Any
+
+
+def load_glb(path: str) -> Tuple[Dict[str, Any], bytes]:
+    """Return the glTF JSON and binary chunk from a GLB file."""
+    with open(path, 'rb') as f:
+        header = f.read(12)
+        if len(header) != 12:
+            raise ValueError('File too short')
+        magic, version, length = struct.unpack('<4sII', header)
+        if magic != b'glTF':
+            raise ValueError('Not a GLB file')
+        data = f.read()
+
+    offset = 0
+    json_chunk = None
+    bin_chunk = b''
+    while offset < len(data):
+        if offset + 8 > len(data):
+            break
+        chunk_length, chunk_type = struct.unpack('<II', data[offset:offset+8])
+        offset += 8
+        chunk_data = data[offset:offset+chunk_length]
+        offset += chunk_length
+        if chunk_type == 0x4E4F534A:  # JSON
+            json_chunk = json.loads(chunk_data.decode('utf-8'))
+        elif chunk_type == 0x004E4942:  # BIN
+            bin_chunk = chunk_data
+
+    if json_chunk is None:
+        raise ValueError('No JSON chunk found in GLB')
+    return json_chunk, bin_chunk
+
+
+def analyze(path: str) -> Dict[str, Any]:
+    gltf, _ = load_glb(path)
+    details = {
+        'num_nodes': len(gltf.get('nodes', [])),
+        'num_meshes': len(gltf.get('meshes', [])),
+        'num_skins': len(gltf.get('skins', [])),
+        'num_animations': len(gltf.get('animations', [])),
+        'skins': []
+    }
+    for skin in gltf.get('skins', []):
+        details['skins'].append({
+            'joints': len(skin.get('joints', [])),
+            'skeleton_root': skin.get('skeleton')
+        })
+    return details
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print('Usage: glbanalyzer.py model.glb')
+        return 1
+    details = analyze(argv[0])
+    print(json.dumps(details, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="styles/responsive.css">
   <link rel="stylesheet" href="styles/map.css">
   <link rel="stylesheet" href="styles/changelog.css">
+  <link rel="stylesheet" href="styles/options.css">
   <script type="importmap">
     {
       "imports": {

--- a/js/downloader.js
+++ b/js/downloader.js
@@ -1,0 +1,33 @@
+export class Downloader {
+  async download(url, progressCallback) {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}`);
+    }
+    const contentLength = parseInt(response.headers.get('Content-Length')) || 0;
+    const reader = response.body.getReader();
+    let received = 0;
+    const chunks = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      received += value.length;
+      if (progressCallback && contentLength) {
+        progressCallback(received / contentLength);
+      }
+    }
+    return new Blob(chunks);
+  }
+
+  async preloadAssets(assets, progressCallback) {
+    const results = {};
+    for (const asset of assets) {
+      const blob = await this.download(asset.url, p => {
+        if (progressCallback) progressCallback(asset, p);
+      });
+      results[asset.name] = blob;
+    }
+    return results;
+  }
+}

--- a/js/uiManager.js
+++ b/js/uiManager.js
@@ -6,6 +6,7 @@ import { CharacterCreatorUI } from '../ui/characterCreatorUI.js';
 import { AdModal } from '../ui/adModal.js';
 import { InventoryUI } from '../ui/inventoryUI.js';
 import { MapUI } from '../ui/mapUI.js';
+import { OptionsUI } from '../ui/optionsUI.js';
 
 export class UIManager {
     constructor(dependencies) {
@@ -20,6 +21,7 @@ export class UIManager {
         new ChangelogUI(this.dependencies).create();
         new ChatUI(this.dependencies).create();
         new CharacterCreatorUI(this.dependencies).create();
+        new OptionsUI().create();
         new AdModal(this.dependencies).setup();
 
         this.inventoryUI = new InventoryUI(this.dependencies);

--- a/skeleton_rigger.py
+++ b/skeleton_rigger.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Command line tool that prints skeleton hierarchy using glbanalyzer."""
+
+import sys
+import json
+from glbanalyzer import load_glb
+
+
+def print_skeleton(gltf):
+    nodes = gltf.get('nodes', [])
+    skins = gltf.get('skins', [])
+    for idx, skin in enumerate(skins):
+        print(f'Skeleton {idx}:')
+        joints = skin.get('joints', [])
+        for j in joints:
+            node = nodes[j]
+            name = node.get('name', f'node{j}')
+            print(f'  - {name}')
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print('Usage: skeleton_rigger.py model.glb')
+        return 1
+    gltf, _ = load_glb(argv[0])
+    print_skeleton(gltf)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/styles/options.css
+++ b/styles/options.css
@@ -1,0 +1,51 @@
+#options-button {
+  position: fixed;
+  bottom: 180px;
+  right: 50px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  text-align: center;
+  line-height: 60px;
+  font-weight: bold;
+  color: #333;
+  z-index: 1000;
+  touch-action: none;
+  cursor: pointer;
+}
+
+#options-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 20px;
+  border-radius: 10px;
+  z-index: 2100;
+  width: 90%;
+  max-width: 400px;
+  display: none;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+#close-options {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 20px;
+  height: 20px;
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+  text-align: center;
+  line-height: 20px;
+  font-weight: bold;
+  color: #333;
+  cursor: pointer;
+}
+
+#download-status {
+  margin-top: 10px;
+}

--- a/ui/optionsUI.js
+++ b/ui/optionsUI.js
@@ -1,0 +1,53 @@
+import { Downloader } from '../js/downloader.js';
+
+export class OptionsUI {
+    constructor() {
+        this.downloader = new Downloader();
+    }
+
+    create() {
+        const container = document.getElementById('game-container');
+        const button = document.createElement('div');
+        button.id = 'options-button';
+        button.innerText = 'OPTIONS';
+        container.appendChild(button);
+
+        const modal = document.createElement('div');
+        modal.id = 'options-modal';
+        modal.style.display = 'none';
+        modal.innerHTML = `
+            <div id="close-options">✕</div>
+            <button id="download-assets">Download Assets</button>
+            <div id="download-status"></div>
+        `;
+        container.appendChild(modal);
+
+        button.addEventListener('click', () => {
+            modal.style.display = 'block';
+        });
+
+        modal.querySelector('#close-options').addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+
+        modal.querySelector('#download-assets').addEventListener('click', () => {
+            this.downloadExternalAssets();
+        });
+    }
+
+    async downloadExternalAssets() {
+        const status = document.getElementById('download-status');
+        status.textContent = 'Loading asset list...';
+        try {
+            const response = await fetch('assets.json');
+            const data = await response.json();
+            const external = data.assets.filter(a => /^https?:/.test(a.url));
+            await this.downloader.preloadAssets(external, (asset, p) => {
+                status.textContent = `Downloading ${asset.name} ${(p * 100).toFixed(0)}%`;
+            });
+            status.textContent = 'All assets downloaded.';
+        } catch (e) {
+            status.textContent = 'Failed to download assets.';
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- list new GLB assets in `assets.json`
- add options UI with asset download support
- create downloader utility for external asset preloading
- load options UI from `UIManager`
- include new stylesheet for options panel
- implement `glbanalyzer.py` and `skeleton_rigger.py` utilities
- update changelog

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dcc25eb888332adaae943f52f984d