### PR TITLE
Fix remote animation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2309 Update remote players to run custom animations each frame
 - 2257 Add animated player replace button and improved options styling
 - 2242 Add options menu with asset downloader and glb analysis scripts
 - 2221 Document new agents directory and split instructions
@@ -10,7 +11,6 @@
 - 2205 Display changelog in modal overlay
 - 2153 Add changelog button above chat
 - 2147 Add HouseBlocks mesh kit
-- 2110 Fix build tool using undefined material index in object creator
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -19,4 +19,5 @@
 - 1928 Add rotate and undo buttons to basic build mode
 - 2018 Add map UI button and close control
 - 2057 Rework character creator modal layout for clearer flow
+- 2110 Fix build tool using undefined material index in object creator
 

--- a/js/multiplayerManager.js
+++ b/js/multiplayerManager.js
@@ -181,16 +181,20 @@ export class MultiplayerManager {
 
     updatePlayerLabels() {
         const playerModel = this.playerControls.getPlayerModel();
-        
+        const time = performance.now() * 0.001;
+
         for (const clientId in this.otherPlayers) {
             const model = this.otherPlayers[clientId];
             const label = this.playerLabels[clientId];
             const chatBubble = this.chatMessages[clientId];
+            if (model && model.userData.updateAnimations) {
+                model.userData.updateAnimations(time);
+            }
             if (label && model) {
                 this.updateLabelPosition(model, label, chatBubble);
             }
         }
-        
+
         const localChatBubble = this.chatMessages[this.room.clientId];
         if (localChatBubble && playerModel) {
             this.updateLabelPosition(playerModel, null, localChatBubble);


### PR DESCRIPTION
## Summary
- keep only the ten most recent changelog entries
- add note about remote player animation updates
- update changelog archive
- refresh MultiplayerManager to animate remote players every frame

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dd28b722083328d54683d046eab78