### PR TITLE
Add utility CSS classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2025-06-26
+- 2349 Add fixed-button and modal-container utility classes
 - 2314 Add theme stylesheet and replace color constants
 - 2309 Update remote players to run custom animations each frame
 - 2257 Add animated player replace button and improved options styling
@@ -10,7 +11,6 @@
 - 2214 Show sent chat immediately and keep log of messages
 - 2206 Introduce mobile-device class for mobile controls
 - 2205 Display changelog in modal overlay
-- 2153 Add changelog button above chat
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -21,4 +21,5 @@
 - 2057 Rework character creator modal layout for clearer flow
 - 2110 Fix build tool using undefined material index in object creator
 - 2147 Add HouseBlocks mesh kit
+- 2153 Add changelog button above chat
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -87,3 +87,29 @@ button:hover {
 button:active {
   background-color: #d5d5d5;
 }
+
+/* Common utility classes */
+.fixed-button {
+  position: fixed;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  text-align: center;
+  line-height: 60px;
+  font-weight: bold;
+  color: #333;
+  z-index: 1000;
+  touch-action: none;
+  cursor: pointer;
+}
+
+.modal-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: none;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 0 20px var(--black-50);
+}

--- a/styles/changelog.css
+++ b/styles/changelog.css
@@ -1,19 +1,11 @@
 #changelog-modal {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   background-color: var(--black-90);
   color: white;
-  padding: 20px;
-  border-radius: 10px;
   z-index: 2100;
   width: 90%;
   max-width: 600px;
   max-height: 80%;
   overflow-y: auto;
-  display: none;
-  box-shadow: 0 0 20px var(--black-50);
 }
 
 #close-changelog {

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -23,37 +23,15 @@
 }
 
 #chat-button {
-  position: fixed;
   bottom: 50px;
   right: 50px;
   background-color: var(--white-50);
-  border-radius: 50%;
-  width: 60px;
-  height: 60px;
-  text-align: center;
-  line-height: 60px;
-  font-weight: bold;
-  color: #333;
-  z-index: 1000;
-  touch-action: none;
-  cursor: pointer;
 }
 
 #changelog-button {
-  position: fixed;
   bottom: 120px;
   right: 50px;
   background-color: var(--white-50);
-  border-radius: 50%;
-  width: 60px;
-  height: 60px;
-  text-align: center;
-  line-height: 60px;
-  font-weight: bold;
-  color: #333;
-  z-index: 1000;
-  touch-action: none;
-  cursor: pointer;
 }
 
 #close-chat {

--- a/styles/inventory.css
+++ b/styles/inventory.css
@@ -1,17 +1,9 @@
 #inventory-panel {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   background-color: var(--black-90);
   color: white;
-  padding: 20px;
-  border-radius: 10px;
   z-index: 2000;
-  display: none;
   width: 90%;
   max-width: 500px;
-  box-shadow: 0 0 20px var(--black-50);
 }
 
 #inventory-panel h2 {

--- a/styles/map.css
+++ b/styles/map.css
@@ -1,17 +1,9 @@
 #map-container {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     background-color: var(--black-85);
     color: white;
-    padding: 20px;
-    border-radius: 10px;
     z-index: 2100; /* Above build controls etc. */
-    display: none;
     flex-direction: column;
     align-items: center;
-    box-shadow: 0 0 20px var(--black-50);
     border: 2px solid var(--white-20);
 }
 
@@ -65,20 +57,9 @@
 }
 
 #map-button {
-    position: fixed;
     bottom: 50px;
     left: 50px;
     background-color: var(--white-50);
-    border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    text-align: center;
-    line-height: 60px;
-    font-weight: bold;
-    color: #333;
-    z-index: 1000;
-    touch-action: none;
-    cursor: pointer;
 }
 
 #close-map {

--- a/styles/options.css
+++ b/styles/options.css
@@ -1,18 +1,7 @@
 #options-button {
-  position: fixed;
   bottom: 180px;
   right: 50px;
   background-color: var(--white-70);
-  border-radius: 50%;
-  width: 60px;
-  height: 60px;
-  text-align: center;
-  line-height: 60px;
-  font-weight: bold;
-  color: #333;
-  z-index: 1000;
-  touch-action: none;
-  cursor: pointer;
   box-shadow: 0 2px 6px var(--black-30);
   transition: background-color 0.3s, transform 0.2s;
 }
@@ -23,19 +12,11 @@
 }
 
 #options-modal {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   background-color: var(--black-95);
   color: #fff;
-  padding: 20px;
-  border-radius: 10px;
   z-index: 2100;
   width: 90%;
   max-width: 400px;
-  display: none;
-  box-shadow: 0 0 20px var(--black-50);
   font-size: 16px;
 }
 

--- a/ui/changelogUI.js
+++ b/ui/changelogUI.js
@@ -3,11 +3,13 @@ export class ChangelogUI {
         const gameContainer = document.getElementById('game-container');
         const changelogButton = document.createElement('div');
         changelogButton.id = 'changelog-button';
+        changelogButton.classList.add('fixed-button');
         changelogButton.innerText = 'CHANGELOG';
         gameContainer.appendChild(changelogButton);
 
         const changelogModal = document.createElement('div');
         changelogModal.id = 'changelog-modal';
+        changelogModal.classList.add('modal-container');
         changelogModal.innerHTML = `
             <div id="close-changelog">✕</div>
             <pre id="changelog-content"></pre>

--- a/ui/chatUI.js
+++ b/ui/chatUI.js
@@ -30,6 +30,7 @@ export class ChatUI {
         
         const chatButton = document.createElement('div');
         chatButton.id = 'chat-button';
+        chatButton.classList.add('fixed-button');
         chatButton.innerText = 'CHAT';
         gameContainer.appendChild(chatButton);
 

--- a/ui/inventoryUI.js
+++ b/ui/inventoryUI.js
@@ -8,6 +8,7 @@ export class InventoryUI {
     create() {
         const inventoryPanel = document.createElement('div');
         inventoryPanel.id = 'inventory-panel';
+        inventoryPanel.classList.add('modal-container');
         inventoryPanel.innerHTML = `
             <h2>Inventory</h2>
             <div class="inventory-grid"></div>

--- a/ui/mapUI.js
+++ b/ui/mapUI.js
@@ -70,6 +70,7 @@ export class MapUI {
         const gameContainer = document.getElementById('game-container');
         this.mapContainer = document.createElement('div');
         this.mapContainer.id = 'map-container';
+        this.mapContainer.classList.add('modal-container');
 
         this.mapContainer.innerHTML = `
             <div id="map-header">
@@ -93,6 +94,7 @@ export class MapUI {
 
         const mapButton = document.createElement('div');
         mapButton.id = 'map-button';
+        mapButton.classList.add('fixed-button');
         mapButton.innerText = 'MAP';
         gameContainer.appendChild(mapButton);
 

--- a/ui/optionsUI.js
+++ b/ui/optionsUI.js
@@ -13,11 +13,13 @@ export class OptionsUI {
         const container = document.getElementById('game-container');
         const button = document.createElement('div');
         button.id = 'options-button';
+        button.classList.add('fixed-button');
         button.innerText = 'OPTIONS';
         container.appendChild(button);
 
         const modal = document.createElement('div');
         modal.id = 'options-modal';
+        modal.classList.add('modal-container');
         modal.style.display = 'none';
         modal.innerHTML = `
             <div id="close-options">✕</div>


### PR DESCRIPTION
## Summary
- add reusable `.fixed-button` and `.modal-container` utilities
- refactor chat, options, map, changelog and inventory styles to use the new utilities
- update UI scripts to apply the classes when creating elements
- keep changelog entries within limit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ddb4f5da08332935421ac390f4a26