### PR TITLE
Add circle button styling for UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025-06-27
 - 1623 Fix stylesheet path in index.html
+- 1633 Add circle-button class and apply to UI buttons
 
 ## 2025-06-26
 - 2314 Add theme stylesheet and replace color constants
@@ -12,7 +13,6 @@
 - 2218 Fade chat bubbles before hiding
 - 2214 Show sent chat immediately and keep log of messages
 - 2206 Introduce mobile-device class for mobile controls
-- 2205 Display changelog in modal overlay
 
 ## Guidelines for future updates
 - List changes in reverse chronological order (newest first).

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -23,3 +23,4 @@
 - 2147 Add HouseBlocks mesh kit
 
 - 2153 Add changelog button above chat
+- 2205 Display changelog in modal overlay

--- a/styles/base.css
+++ b/styles/base.css
@@ -87,3 +87,17 @@ button:hover {
 button:active {
   background-color: #d5d5d5;
 }
+
+.circle-button {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  box-sizing: border-box;
+  font-size: 11px;
+}

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -28,10 +28,7 @@
   right: 50px;
   background-color: var(--white-50);
   border-radius: 50%;
-  width: 60px;
-  height: 60px;
   text-align: center;
-  line-height: 60px;
   font-weight: bold;
   color: #333;
   z-index: 1000;
@@ -45,10 +42,7 @@
   right: 50px;
   background-color: var(--white-50);
   border-radius: 50%;
-  width: 60px;
-  height: 60px;
   text-align: center;
-  line-height: 60px;
   font-weight: bold;
   color: #333;
   z-index: 1000;

--- a/styles/map.css
+++ b/styles/map.css
@@ -70,10 +70,7 @@
     left: 50px;
     background-color: var(--white-50);
     border-radius: 50%;
-    width: 60px;
-    height: 60px;
     text-align: center;
-    line-height: 60px;
     font-weight: bold;
     color: #333;
     z-index: 1000;

--- a/styles/options.css
+++ b/styles/options.css
@@ -4,10 +4,7 @@
   right: 50px;
   background-color: var(--white-70);
   border-radius: 50%;
-  width: 60px;
-  height: 60px;
   text-align: center;
-  line-height: 60px;
   font-weight: bold;
   color: #333;
   z-index: 1000;

--- a/ui/changelogUI.js
+++ b/ui/changelogUI.js
@@ -3,6 +3,7 @@ export class ChangelogUI {
         const gameContainer = document.getElementById('game-container');
         const changelogButton = document.createElement('div');
         changelogButton.id = 'changelog-button';
+        changelogButton.classList.add('circle-button');
         changelogButton.innerText = 'CHANGELOG';
         gameContainer.appendChild(changelogButton);
 

--- a/ui/chatUI.js
+++ b/ui/chatUI.js
@@ -30,6 +30,7 @@ export class ChatUI {
         
         const chatButton = document.createElement('div');
         chatButton.id = 'chat-button';
+        chatButton.classList.add('circle-button');
         chatButton.innerText = 'CHAT';
         gameContainer.appendChild(chatButton);
 

--- a/ui/mapUI.js
+++ b/ui/mapUI.js
@@ -93,6 +93,7 @@ export class MapUI {
 
         const mapButton = document.createElement('div');
         mapButton.id = 'map-button';
+        mapButton.classList.add('circle-button');
         mapButton.innerText = 'MAP';
         gameContainer.appendChild(mapButton);
 

--- a/ui/optionsUI.js
+++ b/ui/optionsUI.js
@@ -14,6 +14,7 @@ export class OptionsUI {
         const container = document.getElementById('game-container');
         const button = document.createElement('div');
         button.id = 'options-button';
+        button.classList.add('circle-button');
         button.innerText = 'OPTIONS';
         container.appendChild(button);
 


### PR DESCRIPTION
## Summary
- create `.circle-button` class in base stylesheet
- remove fixed dimensions from chat, changelog, options and map buttons
- apply `.circle-button` to UI button elements
- archive an old changelog entry and document new change

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ec753b8108332a9b6f9a77e712c55