### PR TITLE
Fix idle orientation for animated players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2025-06-27
 - 1623 Fix stylesheet path in index.html
 - 1633 Add circle-button class and apply to UI buttons
+- 1742 Fix idle animation orientation for animated player model
 
 ## 2025-06-26
 - 2314 Add theme stylesheet and replace color constants

--- a/js/controls.js
+++ b/js/controls.js
@@ -381,7 +381,8 @@ export class PlayerControls {
       
       if (isMovingNow) {
         const angle = Math.atan2(movement.x, movement.z);
-        this.playerModel.rotation.y = angle;
+        const offset = this.playerModel.userData.rotationOffset || 0;
+        this.playerModel.rotation.y = angle + offset;
       }
       
       // Handle animations
@@ -438,11 +439,12 @@ export class PlayerControls {
           this.isMoving !== this.wasMoving
         )) {
         
+        const offset = this.playerModel.userData.rotationOffset || 0;
         const presenceData = {
           x: newX,
           y: newY,
           z: newZ,
-          rotation: this.playerModel.rotation.y,
+          rotation: this.playerModel.rotation.y - offset,
           moving: this.isMoving,
         };
 

--- a/js/player.js
+++ b/js/player.js
@@ -19,6 +19,11 @@ export function setupAnimatedPlayer(model, idleClip, walkClip, runClip) {
 
     actions.idle.play();
 
+    // Apply a rotation offset so the GLB faces the same direction as procedural models
+    const rotationOffset = -Math.PI / 2;
+    model.rotation.y = rotationOffset;
+    model.userData.rotationOffset = rotationOffset;
+
     model.userData.mixer = mixer;
     model.userData.actions = actions;
     model.userData.isAnimatedGLB = true;


### PR DESCRIPTION
## Summary
- correct orientation of GLB-based player models
- adjust controls to send rotation without the GLB offset
- document the fix in the changelog

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ed72b62248332a6649e70a11ff2ce