### PR TITLE
Fix player rotation during movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - 1623 Fix stylesheet path in index.html
 - 1633 Add circle-button class and apply to UI buttons
 - 1742 Fix idle animation orientation for animated player model
+- 1751 Prevent right-turn when walking with animated player
 
 ## 2025-06-26
 - 2314 Add theme stylesheet and replace color constants

--- a/js/controls.js
+++ b/js/controls.js
@@ -381,8 +381,7 @@ export class PlayerControls {
       
       if (isMovingNow) {
         const angle = Math.atan2(movement.x, movement.z);
-        const offset = this.playerModel.userData.rotationOffset || 0;
-        this.playerModel.rotation.y = angle + offset;
+        this.playerModel.rotation.y = angle;
       }
       
       // Handle animations
@@ -439,12 +438,11 @@ export class PlayerControls {
           this.isMoving !== this.wasMoving
         )) {
         
-        const offset = this.playerModel.userData.rotationOffset || 0;
         const presenceData = {
           x: newX,
           y: newY,
           z: newZ,
-          rotation: this.playerModel.rotation.y - offset,
+          rotation: this.playerModel.rotation.y,
           moving: this.isMoving,
         };
 

--- a/js/player.js
+++ b/js/player.js
@@ -19,11 +19,6 @@ export function setupAnimatedPlayer(model, idleClip, walkClip, runClip) {
 
     actions.idle.play();
 
-    // Apply a rotation offset so the GLB faces the same direction as procedural models
-    const rotationOffset = -Math.PI / 2;
-    model.rotation.y = rotationOffset;
-    model.userData.rotationOffset = rotationOffset;
-
     model.userData.mixer = mixer;
     model.userData.actions = actions;
     model.userData.isAnimatedGLB = true;


### PR DESCRIPTION
## Summary
- stop applying rotation offset when walking
- remove unused rotationOffset from animated player setup
- document fix in CHANGELOG

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ed951b4b88332893c9ec29fef0259